### PR TITLE
explicitly load activerecord/activesupport

### DIFF
--- a/lib/joiner/joins.rb
+++ b/lib/joiner/joins.rb
@@ -1,3 +1,6 @@
+require 'active_record'
+require 'active_support/ordered_hash'
+
 class Joiner::Joins
   JoinDependency = ::ActiveRecord::Associations::JoinDependency
 


### PR DESCRIPTION
When used in conjunction with Bundler, ActiveRecord will already be available in the environment, and joiner can access the ActiveRecord and ActiveSupport objects.

When used completely outside Bundler, ActiveRecord and ActiveSupport are not yet loaded, so joiner cannot be used.

This allows the following command to succeed:

```
$ ruby -e "require 'joiner'"
```
